### PR TITLE
Add flv filenames

### DIFF
--- a/content/video/100.md
+++ b/content/video/100.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: ''
 film_title: ''
+flv: secure/courses/soa_gaines_fall2010_zapruder_restored.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/103.md
+++ b/content/video/103.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: ''
 film_title: ''
+flv: secure/courses/soa_gaines_fall2010_zapruder_original.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/327.md
+++ b/content/video/327.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Joris Evens/Henri Storck
 film_title: Borinage
+flv: secure/courses/film_gaines_fall2010_borinage_1_protest.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/328.md
+++ b/content/video/328.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Workers Film and Photo League (Leo Seltzer)
 film_title: Bonus March
+flv: secure/courses/film_gaines_fall2010_bonus_march_excerpt_1_workers_gassed.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/329.md
+++ b/content/video/329.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Alberto Cavalcanti
 film_title: Coal Face
+flv: secure/courses/film_gaines_fall2010_coal_face_excerpt_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/330.md
+++ b/content/video/330.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Joris Evens/Henri Storck
 film_title: ''
+flv: secure/courses/film_gaines_fall2010_borinage_3_socialism.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/331.md
+++ b/content/video/331.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Alberto Cavalcanti
 film_title: Coal Face
+flv: secure/courses/film_gaines_fall2010_coal_face_excerpt_2.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/332.md
+++ b/content/video/332.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Alberto Calvacanti
 film_title: Coal Face
+flv: secure/courses/film_gaines_fall2010_coal_face_excerpt_3.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/333.md
+++ b/content/video/333.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Joris Evens/Henri Storck
 film_title: Borinage
+flv: secure/courses/film_gaines_fall2010_borinage_2_doc_visits_family.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/334.md
+++ b/content/video/334.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Alberto Cavalcanti
 film_title: ''
+flv: secure/courses/film_gaines_fall2010_coal_face_excerpt_4.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/335.md
+++ b/content/video/335.md
@@ -9,6 +9,7 @@ courses: [Documentary Tradition]
 director: Workers Film and Photo League (Leo Seltzer, Joseph Hudyma, Robert Del Duca,
   Lester Balog)
 film_title: Detroit Workers
+flv: secure/courses/film_gaines_fall2010_detroit_workers_excerpt_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/336.md
+++ b/content/video/336.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Ruby Grierson w Arthur Elton/Edgar Anstey/John Taylor
 film_title: ''
+flv: secure/courses/film_gaines_fall2010_housing_problems_excerpt_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/337.md
+++ b/content/video/337.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Ruby Grierson w Arthur Elton/Edgar Anstey/John Taylor
 film_title: ''
+flv: secure/courses/film_gaines_fall2010_housing_problems_excerpt_2.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/338.md
+++ b/content/video/338.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Willard Van Dyke; Ralph Steiner
 film_title: Hands
+flv: secure/courses/film_gaines_fall2010_hands.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/339.md
+++ b/content/video/339.md
@@ -9,6 +9,7 @@ courses: [Documentary Tradition]
 director: Workers Film and Photo League (Leo Seltzer/Leo Hurwitz/Sam Brody/Robert
   Del Duca)
 film_title: Hunger 1932
+flv: secure/courses/film_gaines_fall2010_hunger_1932_excerpt_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/340.md
+++ b/content/video/340.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: EMB Unit (John Grierson/Robert Flaherty)
 film_title: Industrial Britain
+flv: secure/courses/film_gaines_fall2010_industrial_britain_excerpt_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/341.md
+++ b/content/video/341.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: EMB Unit (John Grierson/Robert Flaherty)
 film_title: Industrial Britain
+flv: secure/courses/film_gaines_fall2010_industrial_britain_excerpt_2.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/342.md
+++ b/content/video/342.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Luis Bunuel
 film_title: ''
+flv: secure/courses/film_gaines_fall2010_land_without_bread_part_2.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/343.md
+++ b/content/video/343.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Luis Bunuel
 film_title: Land Without Bread
+flv: secure/courses/film_gaines_fall2010_land_without_bread_part_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/344.md
+++ b/content/video/344.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Leo Hurwitz; Paul Strand
 film_title: ''
+flv: secure/courses/film_gaines_fall2010_native_land_excerpt_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/345.md
+++ b/content/video/345.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Leo Hurwitz; Paul Strand
 film_title: ''
+flv: secure/courses/film_gaines_fall2010_native_land_excerpt_2.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/346.md
+++ b/content/video/346.md
@@ -9,6 +9,7 @@ courses: [Documentary Tradition]
 director: GPO Unit (Harry Watt/Basil Wright/Alberto Cavalcanti/Pat Jackson/W.H. Auden/Benjamin
   Britten)
 film_title: Night Mail
+flv: secure/courses/film_gaines_fall2010_night_mail_excerpt_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/347.md
+++ b/content/video/347.md
@@ -9,6 +9,7 @@ courses: [Documentary Tradition]
 director: GPO Unit (Harry Watt/Basil Wright/Alberto Cavalcanti/Pat Jackson/W.H. Auden/Benjamin
   Britten)
 film_title: Night Mail
+flv: secure/courses/film_gaines_fall2010_night_mail_excerpt_2.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/348.md
+++ b/content/video/348.md
@@ -9,6 +9,7 @@ courses: [Documentary Tradition]
 director: GPO Unit (Harry Watt/Basil Wright/Alberto Cavalcanti/Pat Jackson/W.H. Auden/Benjamin
   Britten)
 film_title: Night Mail
+flv: secure/courses/film_gaines_fall2010_night_mail_excerpt_3.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/349.md
+++ b/content/video/349.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Joris Ivens w Ernest Hemingway/John Dos Passos
 film_title: Spanish Earth
+flv: secure/courses/film_gaines_fall2010_spanish_earth_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/350.md
+++ b/content/video/350.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Joris Ivens w Eernest Hemingway/John Dos Passos
 film_title: Spanish Earth
+flv: secure/courses/film_gaines_fall2010_spanish_earth_2.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/351.md
+++ b/content/video/351.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Willard Van Dyke; Ralph Steiner; Aaron Copeland
 film_title: The City
+flv: secure/courses/film_gaines_fall2010_the_city_excerpt_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/352.md
+++ b/content/video/352.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Willard Van Dyke; Ralph Steiner; Aaron Copeland
 film_title: The City
+flv: secure/courses/film_gaines_fall2010_the_city_excerpt_2.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/353.md
+++ b/content/video/353.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Willard Van Dyke; Ralph Steiner; Aaron Copeland
 film_title: The City
+flv: secure/courses/film_gaines_fall2010_the_city_excerpt_3.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/354.md
+++ b/content/video/354.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Willard Van Dyke; Ralph Steiner; Aaron Copeland
 film_title: ''
+flv: secure/courses/film_gaines_fall2010_the_city_excerpt_4.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/355.md
+++ b/content/video/355.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Robert Flaherty; Francis Flaherty
 film_title: The Land
+flv: secure/courses/film_gaines_fall2010_the_land_excerpt_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/356.md
+++ b/content/video/356.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Pare Lorentz; Leo Hurwitz; Paul Strand; Paul Ivano; Ralph Steiner
 film_title: The Plow that Broke the Plains
+flv: secure/courses/film_gaines_fall2010_the_plow_that_broke_the_plains_excerpt_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/357.md
+++ b/content/video/357.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Pare Lorentz; Floyd Crosby; Willard van Dyke; Virgil Thomson; Thomas Chalmers
 film_title: The River
+flv: secure/courses/film_gaines_fall2010_the_river_excerpt_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/358.md
+++ b/content/video/358.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Pare Lorentz; Floyd Crosby; Willard Van Dyke; Virgil Thomson; Thomas Chalmers
 film_title: The River
+flv: secure/courses/film_gaines_fall2010_the_river_excerpt_2.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/360.md
+++ b/content/video/360.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Pare Lorentz; Floyd Crosby; Willard Van Dyke; Virgil Thomson; Thomas Chalmers
 film_title: The River
+flv: secure/courses/film_gaines_fall2010_the_river_excerpt_3.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/361.md
+++ b/content/video/361.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Pare Lorentz; Floyd Crosby; Willard Van Dyke; Virgil Thomson; Thomas Chalmers
 film_title: The River
+flv: secure/courses/film_gaines_fall2010_the_river_excerpt_4.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/362.md
+++ b/content/video/362.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Workers Film and Photo League (Leo Seltzer)
 film_title: ''
+flv: secure/courses/film_gaines_fall2010_unemployment_special_1931_excerpt_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/365.md
+++ b/content/video/365.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_to_tell_the_truth_buzz_alexander_select_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/366.md
+++ b/content/video/366.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_to_tell_the_truth_albert_mayles_select_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/367.md
+++ b/content/video/367.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_to_tell_the_truth_brian_winston_select_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/368.md
+++ b/content/video/368.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_to_tell_the_truth_brian_winston_select_2.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/369.md
+++ b/content/video/369.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_to_tell_the_truth_brian_winston_select_3.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/370.md
+++ b/content/video/370.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_to_tell_the_truth_brian_winston_select_4.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/371.md
+++ b/content/video/371.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_to_tell_the_truth_buzz_alexander_select_2.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/372.md
+++ b/content/video/372.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_to_tell_the_truth_buzz_alexander_select_3.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/373.md
+++ b/content/video/373.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: ''
+flv: secure/courses/film_gaines_to_tell_the_truth_buzz_alexander_select_4.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/374.md
+++ b/content/video/374.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_to_tell_the_truth_buzz_alexander_select_5.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/375.md
+++ b/content/video/375.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_to_tell_the_truth_buzz_alexander_select_6.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/376.md
+++ b/content/video/376.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_to_tell_the_truth_buzz_alexander_select_7.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/377.md
+++ b/content/video/377.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_to_tell_the_truth_george_stoney_select_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/379.md
+++ b/content/video/379.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_to_tell_the_truth_george_stoney_select_3.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/380.md
+++ b/content/video/380.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_jeffrey_richards_select_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/381.md
+++ b/content/video/381.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_jeffrey_richards_select_2.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/382.md
+++ b/content/video/382.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_jeffrey_richards_select_3.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/383.md
+++ b/content/video/383.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_larry_levine_select_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/384.md
+++ b/content/video/384.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Tom Hurwitz
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_leo_hurwitz_select_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/385.md
+++ b/content/video/385.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Tom Hurwitz
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_leo_hurwitz_select_2.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/386.md
+++ b/content/video/386.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Tom Hurwitz
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_leo_hurwitz_select_3.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/387.md
+++ b/content/video/387.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Tom Hurwitz
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_leo_hurwitz_select_4.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/388.md
+++ b/content/video/388.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Tom Hurwitz
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_leo_hurwitz_select_5.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/389.md
+++ b/content/video/389.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Tom Hurwitz
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_leo_hurwitz_select_6.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/390.md
+++ b/content/video/390.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Tom Hurwitz
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_leo_hurwitz_select_7.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/391.md
+++ b/content/video/391.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_leo_seltzer_select_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/392.md
+++ b/content/video/392.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_leo_seltzer_select_2.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/393.md
+++ b/content/video/393.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_leo_seltzer_select_3.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/394.md
+++ b/content/video/394.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_leo_seltzer_select_4.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/395.md
+++ b/content/video/395.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_leo_seltzer_select_5.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/396.md
+++ b/content/video/396.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_pat_jackson_select_1.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/397.md
+++ b/content/video/397.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_pat_jackson_select_2.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/398.md
+++ b/content/video/398.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Lumiere Productions
 film_title: To Tell The Truth
+flv: secure/courses/film_gaines_pat_jackson_select_3.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/399.md
+++ b/content/video/399.md
@@ -8,6 +8,7 @@ course: ''
 courses: []
 director: Alice Guy Blache
 film_title: La Fee Aux Choux
+flv: secure/courses/film_gaines_fall2010_lafeeauxchoux.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/474.md
+++ b/content/video/474.md
@@ -8,6 +8,7 @@ course: Historiography
 courses: [Historiography]
 director: ''
 film_title: The Strike
+flv: secure/courses/film_gaines_fall2012_strike.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/92.md
+++ b/content/video/92.md
@@ -8,6 +8,7 @@ course: Historiography
 courses: [Historiography]
 director: Oscar Micheaux
 film_title: Within Our Gates
+flv: secure/courses/soa_gaines_fall2010_wog_full.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/93.md
+++ b/content/video/93.md
@@ -8,6 +8,7 @@ course: Historiography
 courses: [Historiography]
 director: Marion E. Wong
 film_title: Curse of the Qwon Gwon
+flv: secure/courses/soa_gaines_fall2010_curse.flv
 location: ''
 media: [video]
 notes: Mandarin Film Co.

--- a/content/video/94.md
+++ b/content/video/94.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Daniel Myrick
 film_title: The Blair Witch Project
+flv: secure/courses/soa_gaines_fall2010_blair_witch_project.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/95.md
+++ b/content/video/95.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: Edgar Morin and Jean Rouch
 film_title: Chronicle of a Summer
+flv: secure/courses/soa_gaines_fall2010_chronicle_of_a_summer.flv
 location: ''
 media: [video]
 notes: ''

--- a/content/video/96.md
+++ b/content/video/96.md
@@ -8,6 +8,7 @@ course: Documentary Tradition
 courses: [Documentary Tradition]
 director: ''
 film_title: ''
+flv: secure/courses/soa_gaines_fall2010_er_the_live_show.flv
 location: ''
 media: [video]
 notes: ''

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+virtualenv -p python3 /tmp/ve3
+/tmp/ve3/bin/pip install bs4
+/tmp/ve3/bin/pip install requests
+echo "now you can run /tmp/ve3/bin/python3 scripts/scrape.py"
+echo "but don't forget to set GAINES_USER and GAINES_PASSWORD environment variables"

--- a/scripts/scrape.py
+++ b/scripts/scrape.py
@@ -3,7 +3,7 @@ from requests import Session
 import os
 import yaml
 from bs4 import BeautifulSoup
-from urllib.parse import urlparse
+from urllib.parse import urlparse, parse_qs
 
 
 HOST = "gainesfilm.qa-lamp.ccnmtl.columbia.edu"
@@ -265,8 +265,27 @@ class Video(BaseType):
     def ntype(self):
         return "video"
 
+    def _embed_src(self):
+        base = "http://ccnmtl.columbia.edu/stream/jsembed?"
+        for s in self.soup('script'):
+            if 'src' not in s.attrs:
+                continue
+            src = s.attrs['src']
+            if src.startswith(base):
+                return src
+        return None
+
+    def flv(self):
+        src = self._embed_src()
+        o = urlparse(src)
+        fields = parse_qs(o.query)
+        f = fields.get('file', [""])
+        return f[0]
+
     def extra_fields(self):
-        return {}
+        return {
+            'flv': self.flv(),
+        }
 
 
 class Document(BaseType):


### PR DESCRIPTION
import the filenames for the FLV files on videos.

We're not actually rendering these, since they all need to be converted to MP4. Getting them into the frontmatter gives us a hook though for running a script that does the conversion in one batch and replaces each FLV with the new MP4.
