### PR TITLE
don't submit filter form on Enter

### DIFF
--- a/layouts/partials/filter.html
+++ b/layouts/partials/filter.html
@@ -3,7 +3,7 @@
 
 <div class="well" id="filter">
 
-    <form class="form form-inline">
+    <form class="form form-inline" onsubmit="return false">
 
         <input type="text" name="filter-q" id="filter-q" placeholder="I'm looking for..." class="form-control"/>
         


### PR DESCRIPTION
results are shown as the user types. Some people still hit 'Enter' out
of habit though, which causes the form to submit and the page to reload.

This just stops that behavior. Not sure if there's a cleaner more modern
way of achieving that...