### PR TITLE
docker setup for serving static files behind CAS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+node_modules
+ve

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM ccnmtl/apache2-cas
+COPY config/apache.conf /etc/apache2/sites-available/000-default.conf
+COPY public /var/www/html/
+COPY scripts/docker-run.sh /usr/local/bin/docker-run.sh
+CMD ["/usr/local/bin/docker-run.sh"]

--- a/config/apache.conf
+++ b/config/apache.conf
@@ -1,0 +1,30 @@
+<VirtualHost *:80>
+
+  # this must be registered as a service
+	# and, obviously, it must resolve to wherever
+	# is proxying this setup. The startup script for
+	# the docker image replaces this with a value
+	# from the environment, so the same image can be
+	# launched in multiple ways
+  CASRootProxiedAs SERVER_NAME
+
+  # CU-specific setup
+	CASLoginURL https://cas.columbia.edu/cas/login
+	CASValidateURL https://cas.columbia.edu/cas/serviceValidate
+
+  CASCookiePath /var/cache/apache2/mod_auth_cas/
+  CASDebug Off
+
+  <Location ~ "/(categories|courses|document|help|image|json|library|page|video|years)">
+		Authtype CAS
+		require valid-user
+	</Location>
+
+	ServerAdmin webmaster@localhost
+	DocumentRoot /var/www/html
+
+  # leave these here to keep logs going to STDOUT/STDERR
+	ErrorLog /proc/self/fd/2
+	CustomLog /proc/self/fd/1 combined
+
+</VirtualHost>

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+echo $SERVER_NAME
+sed -i "s!SERVER_NAME!$SERVER_NAME!" /etc/apache2/sites-available/000-default.conf
+apache2 -DFOREGROUND


### PR DESCRIPTION
The problem: part of this site should be behind CAS auth, but it's a
static generated site, so there's nothing there to do the auth.

To solve that, I built https://github.com/ccnmtl/apache2-cas-docker
which is apache2 with mod_auth_cas packaged into a docker image.

This can now build on that image with its own content.

Here's roughly how the deploy setup will work:

* jenkins does the usual step of using hugo to generate the
  site (populating `public/`) and mucking a bit with the json data.
* then it runs a 'docker build .' to "bake" that site into a docker
  image, which it pushes up to the docker hub
* staging server runs a `docker pull` to get the newer version of the
  image.
* staging server has an upstart config that basically just starts
  `docker run -e SERVER_NAME=https://gainesfilm.stage.ccnmtl.columbia.edu/ ccnmtl/gainesfilm`
* jenkins does a restart on that service after the docker pull
* same thing happens on the production server (docker pull + restart the
  service), but it's just configured with a different `SERVER_NAME` env
  variable.

the `docker-run.sh` script just replaces the `SERVER_NAME` in the apache
config at runtime so we don't have to have duplicate config files for
staging/prod and we can still bake and then deploy one single image that
will go through the pipeline to each environment. If we find that we do
the same thing on other projects that build off `ccnmtl/apache2-cas`, I
may move that technique up to the base image.