### PR TITLE
implement CAS logout

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,6 +14,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
     <script src="/js/lib/lunr.min.js"></script>
     <script src="/js/src/search.js"></script>
+    <script src="/js/src/logout.js"></script>
     
     <style>
     
@@ -64,7 +65,7 @@
                 <li><a href="/media/">Media</a></li>
                 <li><a href="/years/">Years</a></li>
                 <li><a href="/help/">Help</a></li>
-                <li><a href="#">Log Out</a></li>
+                <li><a id="logout-button" href="#">Log Out</a></li>
                 
             </ul>
 

--- a/static/js/src/logout.js
+++ b/static/js/src/logout.js
@@ -1,0 +1,32 @@
+;(function() {
+
+    var deleteCookie = function(name) {
+        // quick and dirty cookie delete.
+        // just clear it and set it to expire in the past.
+        document.cookie = name + '="";path=/;' +
+        'expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+    };
+
+    var getBaseURL = function() {
+        var port = location.port;
+        var portString = '';
+        if (port !== '') {
+            portString = ':' + port;
+        }
+        return location.protocol + '//' + location.hostname + portString + '/';
+    };
+
+    var doLogout = function() {
+        var baseURL = getBaseURL();
+        // delete the local CAS session cookie
+        deleteCookie('MOD_AUTH_CAS');
+
+        // redirect to CAS logout
+        var casLogout = 'https://cas.columbia.edu/cas/logout';
+        window.location.href = casLogout + '?service=' + escape(baseURL);
+    };
+
+    $(document).ready(function() {
+        $('#logout-button').click(doLogout);
+    });
+}());


### PR DESCRIPTION
Client-side version. Basically just delete the mod_auth_cas session
cookie, then send the browser off to the main CAS logout URL. I think
that's about the best we can do for a static site.

For a future PR: just don't even show the logout button unless the user
is logged in (probably by checking for the session cookie).